### PR TITLE
Use Sass variables interpolation for CSS variables

### DIFF
--- a/src/app/theme.service.ts
+++ b/src/app/theme.service.ts
@@ -200,9 +200,9 @@ body {
   --${name}-color: ${p.main};
   --${name}-lighter-color: ${p.lighter};
   --${name}-darker-color: ${p.darker};
-  --text-${name}-color: ${this.getTextColor(p.main)};
-  --text-${name}-lighter-color: ${this.getTextColor(p.lighter)};
-  --text-${name}-darker-color: ${this.getTextColor(p.darker)};
+  --text-${name}-color: #{${this.getTextColor(p.main)}};
+  --text-${name}-lighter-color: #{${this.getTextColor(p.lighter)}};
+  --text-${name}-darker-color: #{${this.getTextColor(p.darker)}};
 }
 
 $mat-${name}: (


### PR DESCRIPTION
You have a bug when you compile the SCSS file with the body's CSS variables. For fixing it you must use SASS variables interpolation.